### PR TITLE
fakeredis 2.36.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7240567f4e1c07a2b3d30c0fd88e5e598e948c2e25850a560727de1d1d3dc946
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7240567f4e1c07a2b3d30c0fd88e5e598e948c2e25850a560727de1d1d3dc946
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
 
 requirements:
@@ -21,9 +21,14 @@ requirements:
   run:
     - python
     - redis-py >=4.3
-    - sortedcontainers >=2.4.0,<3
-- sortedcontainers >=2
-- typing-extensions >=4.7  # [py<311]
+    - sortedcontainers >=2
+    - typing-extensions >=4.7  # [py<311]
+  run_constrained:
+    - lupa >=2.1  # lua
+    - jsonpath-ng >=1.6  # json, vectorset
+    - pyprobables >=0.6  # bf, cf, probabilistic
+    - valkey >=6  # [py>=38]  # valkey
+    - numpy >=2.4.0  # [py>=311]  # vectorset
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ requirements:
     - python
     - redis-py >=4.3
     - sortedcontainers >=2.4.0,<3
-    - typing-extensions >=4.7,<5  # [py<311]
+- sortedcontainers >=2
+- typing-extensions >=4.7  # [py<311]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fakeredis" %}
-{% set version = "2.34.1" %}
+{% set version = "2.36.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4ff55606982972eecce3ab410e03d746c11fe5deda6381d913641fbd8865ea9b
+  sha256: 7240567f4e1c07a2b3d30c0fd88e5e598e948c2e25850a560727de1d1d3dc946
 
 build:
   number: 0


### PR DESCRIPTION
## fakeredis 2.36.1

**Destination channel:** defaults  
**Jira:** PKG-15333 (parent: PKG-13111)

### Links

* [PyPI 2.36.1](https://pypi.org/project/fakeredis/2.36.1/)
* [GitHub](https://github.com/cunla/fakeredis-py)
* [PBP graph (green)](https://package-build.anaconda.com/v1/graph/e5ae4797-e680-4b2f-9ced-33055c155b55)

### Changes

* Updated fakeredis from 2.34.1 to 2.36.1
* Satisfies pydocket 0.19.2 requirement for `fakeredis[lua]>=2.35.0`

### Merge order

1. This PR
2. [pydocket-feedstock#3](https://github.com/AnacondaRecipes/pydocket-feedstock/pull/3) (PKG-15285)

### Test plan

* CI graph passes
* `pip check` and `import fakeredis` succeed